### PR TITLE
feat: shim global Buffer

### DIFF
--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -1,4 +1,4 @@
-import { build, emptyDir } from "https://deno.land/x/dnt@0.22.0/mod.ts";
+import { build, emptyDir } from "https://deno.land/x/dnt@0.36.0/mod.ts";
 
 await emptyDir("./npm");
 
@@ -9,6 +9,13 @@ await build({
     deno: {
       test: "dev",
     },
+    undici: true,
+    custom: [
+      {
+        module: "node:buffer",
+        globalNames: ["Buffer"],
+      },
+    ],
   },
   rootTestDir: "./test-node",
   package: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@ import {
 export { getDataFromUrl, getFormat } from "./get-pixels.ts";
 
 const decoders: DecoderMap = {
-  jpg: jpgDecoder,
-  png: (image: Uint8Array) => {
+  jpg: (image) => jpgDecoder(image, { useTArray: true }),
+  png: (image) => {
     return new Promise((resolve, reject) => {
       const png: PNGType = new PNG({ filterType: 4 });
       png.parse(Buffer.from(image), (err, decoded) => {


### PR DESCRIPTION
Shim global Buffer using "node:buffer", which will now work on most runtimes. Also uses the `useTArray` option for jpegs so that that lib doesn't need Buffers

Fixes #3 